### PR TITLE
Update candelabra.json

### DIFF
--- a/src/main/resources/data/beautify/advancements/progression/candelabra.json
+++ b/src/main/resources/data/beautify/advancements/progression/candelabra.json
@@ -1,7 +1,7 @@
 {
   "display": {
     "icon": {
-      "item": "beautify:lamp_candleabra"
+      "item": "beautify:lamp_candelabra"
     },
     "title": "Wicked!",
     "description": "Craft a candelabra",
@@ -18,7 +18,7 @@
         "items": [
           {
             "items": [
-              "beautify:lamp_candleabra"
+              "beautify:lamp_candelabra"
             ]
           }
         ]


### PR DESCRIPTION
typo fixed to match item_name

item_names are 'cand**el**abra', but there are many more instances of the spelling 'cand**le**abra' that could be changed. The few i am suggesting will fix the missing advancements.